### PR TITLE
Fix openmp symbol and python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
+# Run with:
+#    make install PYTHON=python3
+# for a Python3 install
+PYTHON=python
 
 all: _festival.so
 
 _festival.so: _festival.cpp
-	CFLAGS="-g" python setup.py build
+	CFLAGS="-g -fopenmp" $(PYTHON) setup.py build
 	ln -sf build/*/_festival*.so _festival.so
 
+install: all
+	$(PYTHON) setup.py install
+
 test: all
-	python test.py
+	$(PYTHON) test.py
 
 clean:
-	python setup.py clean
+	$(PYTHON) setup.py clean
 	rm -rf build _festival.so *.pyc


### PR DESCRIPTION
To avoid seeing a "undefined symbol: omp_get_thread_num" error we should build with -fopenmp.

Also, to install under Python3 we allow the python command to be set from the command line under make.