### PR TITLE
fix #8 on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,10 @@ pyfestival creates a C module built on top of the festival source code, making i
 pyfestival supports (and is tested on) Python 2.7+ including Python 3
 """
 
-libraries = ['Festival', 'estools', 'estbase', 'eststring']
+libraries = ['Festival', 'estools', 'estbase', 'eststring', 'ncurses']
 
 if get_platform().startswith('macosx-'):
     macos_frameworks = ['CoreAudio', 'AudioToolbox', 'Carbon']
-    libraries.append('ncurses')
 else:
     macos_frameworks = []
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ pyfestival creates a C module built on top of the festival source code, making i
 pyfestival supports (and is tested on) Python 2.7+ including Python 3
 """
 
-libraries = ['Festival', 'estools', 'estbase', 'eststring', 'ncurses']
+libraries = ['Festival', 'estools', 'estbase', 'eststring', 'ncurses', 'gomp']
 
 if get_platform().startswith('macosx-'):
     macos_frameworks = ['CoreAudio', 'AudioToolbox', 'Carbon']


### PR DESCRIPTION
ncurces fixes 
`ImportError: /home/pi/pyfestival/_festival.so: undefined symbol: tgetnum`
gomp fixes
`import _festival ImportError: /lib/x86_64-linux-gnu/libestools.so.2.5: undefined symbol: omp_get_thread_num`

