### PR TITLE
Don't hold the GIL during calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ If your festival/speechtools headers and libs aren't in the standard place, you 
 * `FESTIVAL_INCLUDE` - festival header directory. Default is `/usr/include/festival`
 * `SPEECH_INCLUDE` - speech tools header directory. Default is `/usr/include/speech_tools`
 * `FESTIVAL_LIB` - lib directory for festival/speech tools `/usr/lib`
+
+### Threading notes
+
+Festival is not thread-safe. If you attempt to invoke it from a thread other than which is was imported in then you will see the error:
+```
+SIOD ERROR: the currently assigned stack limit has been exceeded
+```
+It may be imported locally in each new thread once the previous thread has exited.

--- a/_festival.cpp
+++ b/_festival.cpp
@@ -119,15 +119,18 @@ static PyObject* _sayText(PyObject* self, PyObject* args) {
     const char *text;
     if (!PyArg_ParseTuple(args, "s:_sayText", &text)) return NULL;
 
-    bool success;
-    Py_BEGIN_ALLOW_THREADS
+    // Festival doesn't like empty strings, or NULL ones
+    bool success = false;
+    if (text != NULL && text[0] != '\0') {
+        Py_BEGIN_ALLOW_THREADS
 
-    {
-        const std::lock_guard<std::mutex> lock(_lock);
-        success = festival_say_text(text);
+        {
+            const std::lock_guard<std::mutex> lock(_lock);
+            success = festival_say_text(text);
+        }
+
+        Py_END_ALLOW_THREADS
     }
-
-    Py_END_ALLOW_THREADS
 
     if (success) {
         Py_RETURN_TRUE;


### PR DESCRIPTION
```
Release the GIL during calls to the C library. This allows other threads in the
Python process to progress while the library is busy talking etc.
```

This commit means that pyfestival can be invoked in worker thread while the main thread carries on doing whatever it is that it does.

iamsrp